### PR TITLE
**fix**: Add  No Access permission to transferToInventory (#628)

### DIFF
--- a/mud-contracts/world-v2/src/codegen/world/IAccessSystem.sol
+++ b/mud-contracts/world-v2/src/codegen/world/IAccessSystem.sol
@@ -33,6 +33,7 @@ interface IAccessSystem {
   error Access_NotEphemeralOwnerOrCallAccessWithEphemeralOwner(address caller, uint256 smartObjectId);
   error Access_NotAdminSupportedOrDirectOwner(address caller, uint256 smartObjectId);
   error Access_NotAdminSupportedOrDirectOwnerGates(address caller, uint256 smartObjectId);
+  error Access_NoAccess();
 
   function evefrontier__onlyOwnerOrEphemeralTransferRole(uint256 smartObjectId, bytes memory data) external view;
 
@@ -83,6 +84,8 @@ interface IAccessSystem {
   function evefrontier__onlyAdminOrClassScopedAccess(uint256 smartObjectId, bytes memory data) external view;
 
   function evefrontier__onlySmartAssemblyClassScopedAccess(uint256 smartObjectId, bytes memory data) external view;
+
+  function evefrontier__noAccess(uint256 entityId, bytes memory targetCallData) external view;
 
   function evefrontier__isAdmin(address caller) external view returns (bool);
 

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/codegen/systems/AccessSystemLib.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/codegen/systems/AccessSystemLib.sol
@@ -57,6 +57,7 @@ library AccessSystemLib {
   error Access_NotEphemeralOwnerOrCallAccessWithEphemeralOwner(address caller, uint256 smartObjectId);
   error Access_NotAdminSupportedOrDirectOwner(address caller, uint256 smartObjectId);
   error Access_NotAdminSupportedOrDirectOwnerGates(address caller, uint256 smartObjectId);
+  error Access_NoAccess();
 
   function onlyOwnerOrEphemeralTransferRole(
     AccessSystemType self,
@@ -204,6 +205,10 @@ library AccessSystemLib {
     bytes memory data
   ) internal view {
     return CallWrapper(self.toResourceId(), address(0)).onlySmartAssemblyClassScopedAccess(smartObjectId, data);
+  }
+
+  function noAccess(AccessSystemType self, uint256 entityId, bytes memory targetCallData) internal view {
+    return CallWrapper(self.toResourceId(), address(0)).noAccess(entityId, targetCallData);
   }
 
   function isAdmin(AccessSystemType self, address caller) internal view returns (bool) {
@@ -708,6 +713,19 @@ library AccessSystemLib {
     abi.decode(returnData, (bytes));
   }
 
+  function noAccess(CallWrapper memory self, uint256 entityId, bytes memory targetCallData) internal view {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert AccessSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall = abi.encodeCall(_noAccess_uint256_bytes.noAccess, (entityId, targetCallData));
+    bytes memory worldCall = self.from == address(0)
+      ? abi.encodeCall(IWorldCall.call, (self.systemId, systemCall))
+      : abi.encodeCall(IWorldCall.callFrom, (self.from, self.systemId, systemCall));
+    (bool success, bytes memory returnData) = address(_world()).staticcall(worldCall);
+    if (!success) revertWithBytes(returnData);
+    abi.decode(returnData, (bytes));
+  }
+
   function isAdmin(CallWrapper memory self, address caller) internal view returns (bool) {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert AccessSystemLib_CallingFromRootSystem();
@@ -1136,6 +1154,11 @@ library AccessSystemLib {
     SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
   }
 
+  function noAccess(RootCallWrapper memory self, uint256 entityId, bytes memory targetCallData) internal view {
+    bytes memory systemCall = abi.encodeCall(_noAccess_uint256_bytes.noAccess, (entityId, targetCallData));
+    SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
+  }
+
   function isAdmin(RootCallWrapper memory self, address caller) internal view returns (bool) {
     bytes memory systemCall = abi.encodeCall(_isAdmin_address.isAdmin, (caller));
 
@@ -1379,6 +1402,10 @@ interface _onlyAdminOrClassScopedAccess_uint256_bytes {
 
 interface _onlySmartAssemblyClassScopedAccess_uint256_bytes {
   function onlySmartAssemblyClassScopedAccess(uint256 smartObjectId, bytes memory data) external;
+}
+
+interface _noAccess_uint256_bytes {
+  function noAccess(uint256 entityId, bytes memory targetCallData) external;
 }
 
 interface _isAdmin_address {

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/EveSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/EveSystem.sol
@@ -534,7 +534,7 @@ contract EveSystem is IEveSystem, SmartObjectFramework {
       inventoryInteractSystem.toResourceId(),
       InventoryInteractSystem.transferToInventory.selector,
       accessSystem.toResourceId(),
-      AccessSystem.onlyOwnerOrInventoryTransferRole.selector
+      AccessSystem.noAccess.selector
     );
     accessConfigSystem.setAccessEnforcement(
       inventoryInteractSystem.toResourceId(),

--- a/mud-contracts/world-v2/src/namespaces/evefrontier/systems/access-system/AccessSystem.sol
+++ b/mud-contracts/world-v2/src/namespaces/evefrontier/systems/access-system/AccessSystem.sol
@@ -49,6 +49,7 @@ contract AccessSystem is SmartObjectFramework {
   error Access_NotEphemeralOwnerOrCallAccessWithEphemeralOwner(address caller, uint256 smartObjectId);
   error Access_NotAdminSupportedOrDirectOwner(address caller, uint256 smartObjectId);
   error Access_NotAdminSupportedOrDirectOwnerGates(address caller, uint256 smartObjectId);
+  error Access_NoAccess();
 
   function onlyOwnerOrEphemeralTransferRole(uint256 smartObjectId, bytes memory data) public view {
     uint256 callCount = IWorldWithContext(_world()).getWorldCallCount();
@@ -427,6 +428,10 @@ contract AccessSystem is SmartObjectFramework {
     }
 
     revert Access_NotClassScoped(msgSender, smartObjectId);
+  }
+
+  function noAccess(uint256 entityId, bytes memory targetCallData) public view {
+    revert Access_NoAccess();
   }
 
   function isAdmin(address caller) public view returns (bool) {

--- a/mud-contracts/world-v2/test/inventory/InventoryInteractTest.t.sol
+++ b/mud-contracts/world-v2/test/inventory/InventoryInteractTest.t.sol
@@ -15,6 +15,7 @@ import { RESOURCE_SYSTEM } from "@latticexyz/world/src/worldResourceTypes.sol";
 
 // Smart Object Framework imports
 import { IWorldWithContext } from "@eveworld/smart-object-framework-v2/src/IWorldWithContext.sol";
+import { AccessConfigSystem, accessConfigSystem } from "@eveworld/smart-object-framework-v2/src/namespaces/evefrontier/codegen/systems/AccessConfigSystemLib.sol";
 import { Entity } from "@eveworld/smart-object-framework-v2/src/namespaces/evefrontier/codegen/tables/Entity.sol";
 import { entitySystem } from "@eveworld/smart-object-framework-v2/src/namespaces/evefrontier/codegen/systems/EntitySystemLib.sol";
 import { Role, HasRole } from "@eveworld/smart-object-framework-v2/src/namespaces/evefrontier/codegen/index.sol";
@@ -27,7 +28,7 @@ import { DeployableSystem, deployableSystem } from "../../src/namespaces/evefron
 import { InventorySystem, inventorySystem } from "../../src/namespaces/evefrontier/codegen/systems/InventorySystemLib.sol";
 import { InventoryInteractSystem, inventoryInteractSystem } from "../../src/namespaces/evefrontier/codegen/systems/InventoryInteractSystemLib.sol";
 import { SmartStorageUnitSystem, smartStorageUnitSystem } from "../../src/namespaces/evefrontier/codegen/systems/SmartStorageUnitSystemLib.sol";
-import { AccessSystem } from "../../src/namespaces/evefrontier/codegen/systems/AccessSystemLib.sol";
+import { AccessSystem, accessSystem } from "../../src/namespaces/evefrontier/codegen/systems/AccessSystemLib.sol";
 
 // Types and parameters
 import { EntityRecordParams } from "../../src/namespaces/evefrontier/systems/entity-record/types.sol";
@@ -49,7 +50,7 @@ contract CustomInventoryInteractSystem is System {
   }
 }
 
-contract EphemeralInteractTest is MudTest {
+contract InventoryInteractTest is MudTest {
   using WorldResourceIdInstance for ResourceId;
 
   IWorldWithContext public world;
@@ -199,6 +200,7 @@ contract EphemeralInteractTest is MudTest {
   }
 
   function test_transferToInventory() public {
+    vm.pauseGasMetering();
     // First, add items to primary inventory
     InventoryItemParams[] memory itemParams = new InventoryItemParams[](2);
     itemParams[0] = InventoryItemParams({ smartObjectId: item1ObjectId, quantity: 1 });
@@ -227,11 +229,40 @@ contract EphemeralInteractTest is MudTest {
       smartObjectId: item2ObjectId,
       quantity: 3 // Transfer part of item2
     });
-    vm.pauseGasMetering();
+
+    // Expect revert due to no access
+    vm.expectRevert(abi.encodeWithSelector(AccessSystem.Access_NoAccess.selector));
+    vm.startPrank(alice);
+    world.call(
+      inventoryInteractSystem.toResourceId(),
+      abi.encodeWithSelector(
+        InventoryInteractSystem.transferToInventory.selector,
+        inventoryObjectId,
+        inventoryObjectId2,
+        transferParams
+      )
+    );
+
+    // Allow transferToInventory access to test functionality
+    vm.startPrank(deployer);
+    accessConfigSystem.configureAccess(
+      inventoryInteractSystem.toResourceId(),
+      InventoryInteractSystem.transferToInventory.selector,
+      accessSystem.toResourceId(),
+      AccessSystem.onlyOwnerOrInventoryTransferRole.selector
+    );
+    accessConfigSystem.setAccessEnforcement(
+      inventoryInteractSystem.toResourceId(),
+      InventoryInteractSystem.transferToInventory.selector,
+      true
+    );
+    vm.stopPrank();
+
     // Direct call with alice is allowed (SSU owner)
     vm.startPrank(alice);
-    inventoryInteractSystem.transferToInventory(inventoryObjectId, inventoryObjectId2, transferParams);
     vm.resumeGasMetering();
+    inventoryInteractSystem.transferToInventory(inventoryObjectId, inventoryObjectId2, transferParams);
+    vm.pauseGasMetering();
     // Verify state after the direct call
     // Check primary inventory - should have less items now
     assertEq(Inventory.lengthItems(inventoryObjectId), 1); // item1 completely gone


### PR DESCRIPTION
Correctly add the `NoAccess` permissions to the
`InventoryInteract.transferToInventory` call.

This functionality is here to lay the groundwork for future location bounded uses cases between separate Smart Assembly inventories.
 
It now correctly has the `No Access` permission level until we adjust it later with enforcement of location bounded digital physics rules

